### PR TITLE
RA-806

### DIFF
--- a/omod/src/main/webapp/resources/scripts/angular-common.js
+++ b/omod/src/main/webapp/resources/scripts/angular-common.js
@@ -16,11 +16,6 @@ angular.module('uicommons.common', []).
 
         // to prevent the browser from displaying a password pop-up in case of an authentication error
         $httpProvider.defaults.headers.common['Disable-WWW-Authenticate'] = 'true';
-        
-        // prevent IE from caching GET request
-        $httpProvider.defaults.headers.common["Cache-Control"] = "no-cache";
-        $httpProvider.defaults.headers.common.Pragma = "no-cache";
-        $httpProvider.defaults.headers.common["If-Modified-Since"] = "0";
     }).
 
     run(['$rootScope', '$window', function ($rootScope, $window) {


### PR DESCRIPTION
Changes following review
- remove IE caching avoidance code: it is non-standard a bit of a hack
and doesn't actually work with IE.
- without this hack, chrome and firefox work fine