### PR TITLE
Fix xss issue in infoMessage popups on patient dashboard

### DIFF
--- a/omod/src/main/webapp/fragments/infoAndErrorMessage.gsp
+++ b/omod/src/main/webapp/fragments/infoAndErrorMessage.gsp
@@ -4,10 +4,10 @@
 
 <script type="text/javascript">
      <% if (infoMessage && toastMessage) { %>
-        emr.successMessage("${ ui.message(infoMessage)}");      
+        emr.successMessage("${ ui.encodeHtmlContent(ui.message(infoMessage))}");
     <% } %>
     <% if (errorMessage && toastMessage) { %>
-           emr.errorMessage("${ ui.message(errorMessage)}");      
+           emr.errorMessage("${ ui.encodeHtmlContent(ui.message(errorMessage))}");
     <% } %>
 </script>
 
@@ -16,7 +16,7 @@
         <div class="text">
             <i class="icon-remove medium"></i>
             <% if (errorMessage) { %>
-                <p>${ ui.message(errorMessage) }</p>
+                <p>${ ui.encodeHtmlContent(ui.message(errorMessage)) }</p>
             <% } %>
         </div>
         <div class="close-icon"><i class="icon-remove"></i></div>
@@ -28,7 +28,7 @@
         <div class="text">
             <i class="icon-ok medium"></i>
             <% if (infoMessage) { %>
-            <p>${ ui.message(infoMessage) }</p>
+            <p>${ ui.encodeHtmlContent(ui.message(infoMessage)) }</p>
             <placeholder></placeholder>
             <% } %>
         </div>


### PR DESCRIPTION
This vulnerability can be triggered in two ways:
(1) Create a patient with given, middle, or family name that contains <script>alert('xss');</script>
(2) Make any edit to a patient with pre-existing xss in one of the name fields, then submit