### PR TITLE
RA-1352: Fixed field separation display for names

### DIFF
--- a/omod/src/main/webapp/resources/scripts/navigator/navigatorModels.js
+++ b/omod/src/main/webapp/resources/scripts/navigator/navigatorModels.js
@@ -357,6 +357,7 @@ QuestionModel.prototype.determineDisplayValue = function() {
     }
     else {
         this.valueAsText = fieldDisplayValues.join(this.fieldSeparator);
+        this.valueAsTextNoSeparator = fieldDisplayValues.join(" ");
     }
 }
 QuestionModel.prototype.select = function() {
@@ -662,9 +663,14 @@ ConfirmationSectionModel.prototype.select = function() {
                     }
                     // question title is label, all fields on single line
                     else {
-                        summaryDiv.append("<p><span class='title'>" + question.title().text() + ": </span>"
+                        if (question.title().text() == "Name") {
+                            summaryDiv.append("<p><span class='title'>" + question.title().text() + ": </span>"
+                            + (question.valueAsTextNoSeparator) + "</p>");
+                        }
+                        else {
+                            summaryDiv.append("<p><span class='title'>" + question.title().text() + ": </span>"
                             + (question.valueAsText && !/^\s*$/.test(question.valueAsText) ? question.valueAsText : "--") + "</p>");
-
+                        }
                     }
                 }
 


### PR DESCRIPTION
We have made changes to the uicommons module that will allow all Name IDs to display correctly when a name has been input. Note: This has been checked across all naming convention methods from the Administration menu. 