### PR TITLE
RA-1707: Fix position and length of login fields

### DIFF
--- a/scss/src/main/resources/sass/reference/fragments/_login.scss
+++ b/scss/src/main/resources/sass/reference/fragments/_login.scss
@@ -3,7 +3,7 @@
   padding: 10px;
 
   p {
-    margin-right: 20px;
+    margin-right: 10px;
     text-align: right;
 
     input[type=text], input[type=password] {
@@ -48,5 +48,29 @@
 @media (min-width: 992px){
   #login-form ul {
     font-size: 1.0em;
+  }
+}
+
+@media screen and (max-width: 992px) and (min-width: 910px){
+  #username,#password {
+    width: 400px;
+  }
+}
+
+@media screen and (max-width: 910px) and (min-width: 810px){
+  #username,#password {
+    width: 350px;
+  }
+}
+
+@media screen and (max-width: 810px) and (min-width: 710px){
+  #username,#password {
+    width: 300px;
+  }
+}
+
+@media screen and (max-width: 710px) and (min-width: 670px){
+  #username,#password {
+    width: 279px;
   }
 }


### PR DESCRIPTION
Here is the link to the issue : https://issues.openmrs.org/browse/RA-1707.

Description: Changed the right margin so that there was enough space to align the elements in single line.

Before Change:
![Screenshot from 2020-03-28 16-48-44](https://user-images.githubusercontent.com/39997970/77821953-42aadd00-7114-11ea-8914-19415f5b7882.png)
 
After Change:
![Screenshot from 2020-03-28 16-48-17](https://user-images.githubusercontent.com/39997970/77821960-58200700-7114-11ea-9e3b-312d4d621a3a.png)
