### PR TITLE
Fix broken font path

### DIFF
--- a/scss/src/main/resources/sass/reference/_variables.scss
+++ b/scss/src/main/resources/sass/reference/_variables.scss
@@ -8,8 +8,8 @@ $primaryBoldFont: "OpenSansBold";
 $primaryLightFont: "OpenSansLight";
 $primaryItalicFont: "OpenSansItalic";
 $iconFont: "FontAwesome";
-$fontPath: "../../uicommons/fonts";
-$fa-font-path: "../../uicommons/font-awesome-5";
+$fontPath: "../../fonts";
+$fa-font-path: "../../font-awesome-5";
 
 //colors
 $alertBackground: #FFFDF0;


### PR DESCRIPTION
Fixes fe6680771d7a528f24065c27cd5fed3ac56fe277 , #71 .

Attn @mogoodrich and @dkayiwa .

If this has any effect on the RefApp or PIH EMR, I don't know where it would be. So I don't really know how to QA this. I can only assume that this isn't actually the code that governs font loading for either. The URLs for font loading appear unaffected by this change. The only difference it seems to make is with the [LabWorkflow OWA](https://github.com/openmrs/openmrs-owa-labworkflow).

EDIT: My previous comments were actually about PIH EMR, not the RefApp. But the same applies.