### PR TITLE
UICM-96: Datetime picker start and end dates to be dateISOFormatted.

### DIFF
--- a/omod/src/main/webapp/fragments/field/datetimepicker.gsp
+++ b/omod/src/main/webapp/fragments/field/datetimepicker.gsp
@@ -120,11 +120,11 @@
         format: "${datePickerFormat}",
 
         <% if (startDate) { %>
-            startDate: "${ startDate instanceof Date ? dateStringFormat.format(startDate) : startDate }",
+            startDate: "${ startDate instanceof Date ? dateISOFormatted.format(startDate) : startDate }",
         <% } %>
 
         <% if (endDate) { %>
-            endDate: "${ endDate instanceof Date ? dateStringFormat.format(endDate) : endDate }",
+            endDate: "${ endDate instanceof Date ? dateISOFormatted.format(endDate) : endDate }",
         <% } %>
 
         language: "${ org.openmrs.api.context.Context.getLocale() }",


### PR DESCRIPTION
#### Ticket
https://issues.openmrs.org/browse/UICM-96

#### What I have done
Changed the format of "startDate" and "endDate" to `"yyyy-MM-dd HH:mm:ss"` so it doesn't use words in other languages, (ex in French: _12 déc. 2020 14:10:20_), now it will look like _2020-12-12 14:10:20_.
This way, the datetime widget will always recognize the end/start date.