### PR TITLE
UICM-98: Timezones, Update the datepicker and UiFramework version

### DIFF
--- a/api/src/main/resources/messages_fr.properties
+++ b/api/src/main/resources/messages_fr.properties
@@ -97,7 +97,7 @@ uicommons.month.12=Décembre
 uicommons.saveForm=Enregistrer
 uicommons.cancelForm=Annuler
 
-uicommons.searchPatientHeading=Rechercher un patient (scanner la carte ou par code/nom):
+uicommons.searchPatientHeading=Rechercher un patient (scanner la carte ou par code/Nom):
 uicommons.searchByNameOrIdOrScan=Ex: Y2A4G4
 
 uicommons.units.meters=m

--- a/omod/src/main/webapp/fragments/field/datetimepicker.gsp
+++ b/omod/src/main/webapp/fragments/field/datetimepicker.gsp
@@ -39,10 +39,15 @@
     def defaultDateString = ""
     def defaultDateISOFormatted = ""
     if (defaultDate) {
-        if( ui.handleTimeZones() ) {
-            defaultDateString = ui.format(defaultDate)
-            defaultDateISOFormatted = ui.format(defaultDate)
-        }else{
+        if( ui.convertTimezones() ) {
+            if(useTime){
+                defaultDateString = ui.format(defaultDate)
+                defaultDateISOFormatted = ui.format(defaultDate)
+            } else {
+                defaultDateString = ui.formatDateWithClientTimezone(defaultDate)
+                defaultDateISOFormatted = ui.formatDateWithClientTimezone(defaultDate)
+            }
+        } else {
             defaultDateString = dateStringFormat.format(defaultDate)
             defaultDateISOFormatted = dateISOFormatted.format(defaultDate)
         }
@@ -125,17 +130,17 @@
         format: "${datePickerFormat}",
 
         <% if (startDate) { %>
-            <% if (ui.handleTimeZones()) { %>
+            <% if (ui.convertTimezones()) { %>
                 startDate: "${ startDate instanceof Date ? ui.format(startDate) : startDate }",
-            <% }else{ %>
+            <% } else { %>
                 startDate: "${ startDate instanceof Date ? dateISOFormatted.format(startDate) : startDate }",
             <% } %>
         <% } %>
 
         <% if (endDate) { %>
-            <% if (ui.handleTimeZones()) { %>
+            <% if (ui.convertTimezones()) { %>
                 endDate: "${ endDate instanceof Date ? ui.format(endDate) : endDate }",
-            <% }else{ %>
+            <% } else { %>
                 endDate: "${ endDate instanceof Date ? dateISOFormatted.format(endDate) : endDate }",
             <% } %>
         <% } %>
@@ -155,18 +160,6 @@
             return viewModel.${ config.id }() ? true : false;
         });
         <% } %>
-    <% } %>
-    //Convert to client timezone.
-    <% if (ui.handleTimeZones()) { %>
-        var dateOnUTC = jq("#${ config.id }-field").val();
-        if(dateOnUTC != ''){
-            jq("#${ config.id }-field").val(new Date(dateOnUTC))
-            moment.locale("${ ui.getLocale() }")
-            <%   def format = useTime ? "YYYY-MM-DD HH:mm:ss" : "YYYY-MM-DD"%>
-            <%   def formatDisplay = useTime ? "DD MMM YYYY HH:MM" : "DD MMM YYYY"%>
-            jq("#${ config.id }-display").val(moment(dateOnUTC).format("${formatDisplay}"));
-            jq("#${ config.id }-field").val(moment(dateOnUTC).format("${format}"));
-        }
     <% } %>
 
 </script>

--- a/omod/src/main/webapp/fragments/field/datetimepicker.gsp
+++ b/omod/src/main/webapp/fragments/field/datetimepicker.gsp
@@ -39,8 +39,13 @@
     def defaultDateString = ""
     def defaultDateISOFormatted = ""
     if (defaultDate) {
-        defaultDateString = dateStringFormat.format(defaultDate)
-        defaultDateISOFormatted = dateISOFormatted.format(defaultDate)
+        if( ui.handleTimeZones() ) {
+            defaultDateString = ui.format(defaultDate)
+            defaultDateISOFormatted = ui.format(defaultDate)
+        }else{
+            defaultDateString = dateStringFormat.format(defaultDate)
+            defaultDateISOFormatted = dateISOFormatted.format(defaultDate)
+        }
     }
 
     def startDate
@@ -120,11 +125,19 @@
         format: "${datePickerFormat}",
 
         <% if (startDate) { %>
-            startDate: "${ startDate instanceof Date ? dateISOFormatted.format(startDate) : startDate }",
+            <% if (ui.handleTimeZones()) { %>
+                startDate: "${ startDate instanceof Date ? ui.format(startDate) : startDate }",
+            <% }else{ %>
+                startDate: "${ startDate instanceof Date ? dateISOFormatted.format(startDate) : startDate }",
+            <% } %>
         <% } %>
 
         <% if (endDate) { %>
-            endDate: "${ endDate instanceof Date ? dateISOFormatted.format(endDate) : endDate }",
+            <% if (ui.handleTimeZones()) { %>
+                endDate: "${ endDate instanceof Date ? ui.format(endDate) : endDate }",
+            <% }else{ %>
+                endDate: "${ endDate instanceof Date ? dateISOFormatted.format(endDate) : endDate }",
+            <% } %>
         <% } %>
 
         language: "${ org.openmrs.api.context.Context.getLocale() }",
@@ -143,4 +156,17 @@
         });
         <% } %>
     <% } %>
+    //Convert to client timezone.
+    <% if (ui.handleTimeZones()) { %>
+        var dateOnUTC = jq("#${ config.id }-field").val();
+        if(dateOnUTC != ''){
+            jq("#${ config.id }-field").val(new Date(dateOnUTC))
+            moment.locale("${ ui.getLocale() }")
+            <%   def format = useTime ? "YYYY-MM-DD HH:mm:ss" : "YYYY-MM-DD"%>
+            <%   def formatDisplay = useTime ? "DD MMM YYYY HH:MM" : "DD MMM YYYY"%>
+            jq("#${ config.id }-display").val(moment(dateOnUTC).format("${formatDisplay}"));
+            jq("#${ config.id }-field").val(moment(dateOnUTC).format("${format}"));
+        }
+    <% } %>
+
 </script>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<openMRSVersion>1.12.0</openMRSVersion>
-		<uiframeworkVersion>3.8</uiframeworkVersion>
+		<uiframeworkVersion>3.21.0-SNAPSHOT</uiframeworkVersion>
     </properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
#### Ticket:
https://issues.openmrs.org/browse/UICM-98
#### What I have done:
* Update **datetimepicker.gsp** to support time zones.
* Update UIFR version from 3.8 to 3.21.0-SNAPSHOT to access the new `UiUtils` time zones API.