### PR TITLE
UICM-97: datetimepicker.gsp to consider 24h format instead of 12h format.

### DIFF
--- a/omod/src/main/webapp/fragments/field/datetimepicker.gsp
+++ b/omod/src/main/webapp/fragments/field/datetimepicker.gsp
@@ -51,7 +51,7 @@
         if (startDate instanceof String) {
             try {
             	// parses date strings like (new Date().toString())
-            	fallbackDateStringFormat = new java.text.SimpleDateFormat("E MMM dd hh:mm:ss Z yyyy", java.util.Locale.ENGLISH)
+            	fallbackDateStringFormat = new java.text.SimpleDateFormat("E MMM dd HH:mm:ss Z yyyy", java.util.Locale.ENGLISH)
                 startDate = fallbackDateStringFormat.parse(startDate)
             } catch(Exception e) {
             	// pass
@@ -67,7 +67,7 @@
         if (endDate instanceof String) {
             try {
             	// parses date strings like (new Date().toString())
-            	fallbackDateStringFormat = new java.text.SimpleDateFormat("E MMM dd hh:mm:ss Z yyyy", java.util.Locale.ENGLISH)
+            	fallbackDateStringFormat = new java.text.SimpleDateFormat("E MMM dd HH:mm:ss Z yyyy", java.util.Locale.ENGLISH)
                 endDate = fallbackDateStringFormat.parse(endDate)
             } catch(Exception e) {
             	// pass


### PR DESCRIPTION
**Ticket:** [UICM-97](https://issues.openmrs.org/browse/UICM-97)

**Description:** Changed the mask for parsing end and start date range to consider 24h instead of 12h. Dates from datepicker configuration are being passed as 24h format. Parsing them as 12h format would make midday to be interpreted as midnight.