### PR TITLE
EMPT-84: Fixed XSS in "other" drug input (uicommons)

### DIFF
--- a/omod/src/main/webapp/resources/scripts/directives/coded-or-free-text-answer.js
+++ b/omod/src/main/webapp/resources/scripts/directives/coded-or-free-text-answer.js
@@ -1,4 +1,4 @@
-angular.module('uicommons.widget.coded-or-free-text-answer', [ 'conceptSearchService', 'ui.bootstrap' ])
+angular.module('uicommons.widget.coded-or-free-text-answer', [ 'conceptSearchService', 'ui.bootstrap', 'ngSanitize' ])
 
     .directive('codedOrFreeTextAnswer', ['ConceptSearchService', function(ConceptSearchService) {
 
@@ -15,7 +15,7 @@ angular.module('uicommons.widget.coded-or-free-text-answer', [ 'conceptSearchSer
                 conceptClasses: '@',
                 selection: '@' // default behavior is "ConceptName", but specify "Concept" if you won't be keeping the specific chosen name
             },
-            controller: function($scope) {
+            controller: function($scope, $sanitize) {
                 var conceptOnly = $scope.selection === "Concept";
 
                 $scope.inputId = ($scope.id ? $scope.id : 'coded-or-free-text-answer-' + Math.floor(Math.random() * 10000)) + '-input';
@@ -82,7 +82,7 @@ angular.module('uicommons.widget.coded-or-free-text-answer', [ 'conceptSearchSer
                         return result.concept.display;
                     }
                     else {
-                        return '"' + result.word + '"';
+                        return '"' + $sanitize(result.word) + '"';
                     }
                 }
 


### PR DESCRIPTION
### Description of what I changed
I added ngSanitize to `coded-or-free-text-answer.js` in order to call `$sanitize()` on `result.word`. This prevents the user from typing HTML input that is then shown when it is previewed in the dropdown menu.

I also had to include `angular-santize-min.js` in `allergy.gsp`. 

### Link to ticket
https://issues.openmrs.org/browse/RA-1865

### Issue I worked on
When entering a drug name in the "Other drug" field, input such as `<script>alert(1)</script>` ot `<iframe src=` would result in xss, as the input string was not sanitized when being displayed as a choice preview in the dropdown menu.

### Before fix
Iframe shown for input `<iframe src` (text goes away when I navigate to the screenshot tool)
![image](https://user-images.githubusercontent.com/29798975/114670918-7fbb2080-9cd1-11eb-9262-10819c0cf469.png)

### After fix
Iframe shown for input `<iframe src` (text goes away when I navigate to the screenshot tool)
![image](https://user-images.githubusercontent.com/29798975/114671244-dfb1c700-9cd1-11eb-994a-68caa370c613.png)


### Steps to reproduce
1. Login to OpenMRS
2. If there are no existing patients, register one.
3. Navigate to the dashboard for a patient.
4. Edit Allergies > Add New Allergy
5. For type, select "Drug", and then select the "Other" button.
6. Type `<script>alert(1)</script>` as the allergy name.
7. The script will execute.

@isears 