### PR TITLE
RA-1985 - Change date format when usetime is true

### DIFF
--- a/omod/src/main/webapp/fragments/field/datetimepicker.gsp
+++ b/omod/src/main/webapp/fragments/field/datetimepicker.gsp
@@ -87,8 +87,9 @@
         minuteStep = 5
     }
     if(!datePickerFormat){
-        datePickerFormat = useTime ? "dd M yyyy hh:ii" : "dd M yyyy"
+        datePickerFormat = useTime ? "dd M yyyy HH:mm" :"dd M yyyy"
     }
+
     if(!datePickerLinkFormat){
         datePickerLinkFormat = useTime ? "yyyy-mm-dd hh:ii:ss" : "yyyy-mm-dd"
     }


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/RA-1985

In order to enable a dynamic time in the DateTimePicker, both modes need to be interchangeable

Problem:
Currently, both modes are not compatible,  
- If we edit a visit without using date, and then open said visit with useTime enabled
- The date picker will get confuse and mix the day and the month 

Solution:
Change date format, when using time 