### PR TITLE
RA-1988 - Allow DatetimePicker to support different timezones 

### DIFF
--- a/omod/src/main/webapp/fragments/field/datetimepicker.gsp
+++ b/omod/src/main/webapp/fragments/field/datetimepicker.gsp
@@ -38,12 +38,9 @@
         startDate = config.startDate
         if (startDate instanceof String) {
             try {
-                if(startDate.split("-").length == 1){
-                    startDate = extendedDateStringFormat.parse(startDate)
-                }else {
-                    startDate = shortDateStringFormat.parse(startDate)
-                }
+                startDate = extendedDateStringFormat.parse(startDate)
             } catch(Exception dateWithoutTimeException) {
+                startDate = shortDateStringFormat.parse(startDate)
             }
         }
     }
@@ -54,12 +51,9 @@
         endDate = config.endDate
         if (endDate instanceof String) {
             try {
-                if(endDate.split("-").length == 1){
-                    endDate = extendedDateStringFormat.parse(endDate)
-                }else {
-                    endDate = shortDateStringFormat.parse(endDate)
-                }
+                endDate = extendedDateStringFormat.parse(endDate)
             } catch(Exception dateWithoutTimeException) {
+                endDate = shortDateStringFormat.parse(endDate)
             }
         }
     }
@@ -152,6 +146,18 @@
                 jq("#${ config.id }-field").val(moment(dateOnUTC).format("${format}"));
             }
         })
+    <% } else if (convertTimezones) { %>
+    jQuery("#${ config.id }-wrapper").datetimepicker().on('show hide', function(e) {
+        var dateOnUTC = jq("#${ config.id }-field").val();
+        if (dateOnUTC != '') {
+            jq("#${ config.id }-field").val(new Date(dateOnUTC))
+            moment.locale("${ ui.getLocale() }")
+            <%   def displayFormat = "DD MMM YYYY" %>
+            <%   def inputFormat = "YYYY-MM-DDTHH:mm:ss.sssZ" %>
+            jq("#${ config.id }-display").val(moment(dateOnUTC).format("${displayFormat}"));
+            jq("#${ config.id }-field").val(moment(dateOnUTC).format("${inputFormat}"))
+        }
+    })
     <% } else {  %>
         jQuery("#${ config.id }-wrapper").datetimepicker().on('show hide', function(e) {
             var dateOnUTC = jq("#${ config.id }-field").val();


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/RA-1988

Description:
When using a date time picker (with time), it will not store the date with time-zone information. 
This will result in date being stored always as if was UTC, even when is not. 

Changes done:
- Change initial date string format from "dd MMM yyyy HH:mm" to "dd MMM yyyy HH:mm:ss" (now show's seconds, to be in order with the remaining formats)
- Change date Picker format from "dd M yyyy HH:mm" to "dd M yyyy hh:ii:ss" (this is time used after picking with the date time picker)
- Updating format every time a change happens (this is required in order to send time zone)

Related PR's: 
- https://github.com/openmrs/openmrs-module-htmlformentryui/pull/58
- https://github.com/openmrs/openmrs-module-coreapps/pull/457
