### PR TITLE
RA-1991: Class verification always returns false inside fragments

### DIFF
--- a/omod/src/main/webapp/fragments/field/datetimepicker.gsp
+++ b/omod/src/main/webapp/fragments/field/datetimepicker.gsp
@@ -7,7 +7,7 @@
 
     config.require("id", "label", "formFieldName", "useTime")
 
-    def required = config.classes && config.classes.contains("required")
+    def required = config.classes && config.classes.join(' ').contains("required")
 
     def dateStringFormat
     def dateISOFormatted

--- a/omod/src/main/webapp/fragments/field/dropDown.gsp
+++ b/omod/src/main/webapp/fragments/field/dropDown.gsp
@@ -2,7 +2,7 @@
     config.require("formFieldName")
     config.require("options")
 
-    def required = config.classes && config.classes.contains("required");
+    def required = config.classes && config.classes.join(' ').contains("required");
 
     def selectDataBind = "";
     if (config.depends && config.depends.disable) {

--- a/omod/src/main/webapp/fragments/field/multipleInputDate.gsp
+++ b/omod/src/main/webapp/fragments/field/multipleInputDate.gsp
@@ -101,7 +101,7 @@
 
 <p id="${config.id}">
     <label for="${ config.id }-field">
-        ${ config.label } <% if (config.classes && config.classes.contains("requiredTitle")) { %><span>(${ ui.message("emr.formValidation.messages.requiredField.label") })</span><% } %>
+        ${ config.label } <% if (config.classes && config.classes.join(' ').contains("requiredTitle")) { %><span>(${ ui.message("emr.formValidation.messages.requiredField.label") })</span><% } %>
     </label>
     ${ ui.includeFragment("uicommons", "fieldErrors", [ fieldName: config.formFieldName ]) }
 

--- a/omod/src/main/webapp/fragments/field/passwordField.gsp
+++ b/omod/src/main/webapp/fragments/field/passwordField.gsp
@@ -15,7 +15,7 @@
 
 <p <% if (config.left) { %> class="left" <% } %> >
     <label for="${ config.id }-field">
-        ${ config.label } <% if (config.classes && config.classes.contains("required")) { %>
+        ${ config.label } <% if (config.classes && config.classes.join(' ').contains("required")) { %>
         <span>(${ ui.message("uicommons.requiredField.label") })</span> <% } %>
     </label>
     <input type="password" id="${ config.id }-field" name="${ config.formFieldName }" autocomplete="off"

--- a/omod/src/main/webapp/fragments/field/personAddress.gsp
+++ b/omod/src/main/webapp/fragments/field/personAddress.gsp
@@ -3,7 +3,7 @@
 
     def addressTemplate = config.addressTemplate;
 
-    def required = config.classes && config.classes.contains("required");
+    def required = config.classes && config.classes.join(' ').contains("required");
 %>
 <p>
     <label for="${ config.id }-field">

--- a/omod/src/main/webapp/fragments/field/radioButtons.gsp
+++ b/omod/src/main/webapp/fragments/field/radioButtons.gsp
@@ -3,7 +3,7 @@
     config.require("formFieldName")
     config.require("options")
 
-    def required = config.classes && config.classes.contains("required");
+    def required = config.classes && config.classes.join(' ').contains("required");
     def otherAttributes = ''
     if (config.otherAttributes){
         config.otherAttributes.each{ attr, val ->

--- a/omod/src/main/webapp/fragments/field/text.gsp
+++ b/omod/src/main/webapp/fragments/field/text.gsp
@@ -17,7 +17,7 @@
 
 <p <% if (config.left) { %> class="left" <% } %> >
     <label for="${ config.id }-field">
-        ${ config.label } <% if (config.classes && config.classes.contains("required")) { %><span>(${ ui.message("emr.formValidation.messages.requiredField.label") })</span><% } %>
+        ${ config.label } <% if (config.classes && config.classes.join(' ').contains("required")) { %><span>(${ ui.message("emr.formValidation.messages.requiredField.label") })</span><% } %>
     </label>
     <input type="text" id="${ config.id }-field" name="${ config.formFieldName }" value="${ config.initialValue ?: '' }"
            <% if (config.classes) { %>class="${ config.classes.join(' ') }" <% } %>

--- a/omod/src/main/webapp/fragments/field/textarea.gsp
+++ b/omod/src/main/webapp/fragments/field/textarea.gsp
@@ -8,7 +8,7 @@
 
 <p <% if (config.left) { %> class="left" <% } %> >
     <label for="${ config.id }-field">
-        ${ config.label } <% if (config.classes && config.classes.contains("required")) { %><span>(${ ui.message("emr.formValidation.messages.requiredField.label") })</span><% } %>
+        ${ config.label } <% if (config.classes && config.classes.join(' ').contains("required")) { %><span>(${ ui.message("emr.formValidation.messages.requiredField.label") })</span><% } %>
     </label>
     <textarea id="${ config.id }-field"
               class="form-control form-control-sm form-control-lg form-control-md field-value <% if (config.classes) { config.classes.join(' ') } %>"


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/RA-1991

Bug: 
When validating if a field contains the class "required" the current solution is always returning "false"

Solution: 
By adding ".join(' ')" between  "classes" and ".contains("required")", the function will work as intended

Before: 
config.classes.contains("required")

After: 
config.classes.join(' ').contains("required")

Note: This solution was already being used when adding classes, however it was missing from the required validation