### PR TITLE
UHM-6747, navigate to the question with invalid fields

### DIFF
--- a/omod/src/main/webapp/resources/scripts/navigator/navigatorHandlers.js
+++ b/omod/src/main/webapp/resources/scripts/navigator/navigatorHandlers.js
@@ -274,8 +274,12 @@ var clickedQuestionHandler = function(questions, question, event) {
     var currentQuestionIndex = _.indexOf(questions, currentQuestion);
     var clickedQuestionIndex = _.indexOf(questions, question);
     var shouldSelectClickedQuestion = true;
+    var firstInvalidQuestion = null;
     if(clickedQuestionIndex > currentQuestionIndex) {
         for(var i=currentQuestionIndex; i<clickedQuestionIndex; i++) {
+            if ( !questions[i].isValid() ) {
+              firstInvalidQuestion = questions[i];
+            }
             shouldSelectClickedQuestion = questions[i].isValid() && shouldSelectClickedQuestion;
         }
     }
@@ -284,8 +288,23 @@ var clickedQuestionHandler = function(questions, question, event) {
     shouldSelectClickedQuestion = shouldSelectClickedQuestion && currentQuestion.onExit();
 
     if(!shouldSelectClickedQuestion) {
-        var selectedField = selectedModel(currentQuestion.fields);
-        selectedField && selectedField.select();
+        if ( !currentQuestion.isValid() ) {
+          // stay on the current question if it is invalid
+          var selectedField = selectedModel(currentQuestion.fields);
+          selectedField && selectedField.select();
+        } else if ( firstInvalidQuestion != null ){
+            // navigate forward to the first invalid question
+          currentQuestion.toggleSelection();
+          firstInvalidQuestion.toggleSelection();
+          // firstInvalidQuestion.fields[0].toggleSelection();
+          var goToField = firstInvalidQuestion.firstInvalidField() || firstInvalidQuestion.fields[0];
+          goToField.toggleSelection();
+          goToField.isValid();
+          if(currentQuestion.parentSection != firstInvalidQuestion.parentSection) {
+            currentQuestion.parentSection.toggleSelection();
+            firstInvalidQuestion.parentSection.toggleSelection();
+          }
+        }
     } else {
         currentQuestion.toggleSelection();
         question.toggleSelection();

--- a/omod/src/main/webapp/resources/scripts/navigator/navigatorHandlers.js
+++ b/omod/src/main/webapp/resources/scripts/navigator/navigatorHandlers.js
@@ -296,7 +296,6 @@ var clickedQuestionHandler = function(questions, question, event) {
             // navigate forward to the first invalid question
           currentQuestion.toggleSelection();
           firstInvalidQuestion.toggleSelection();
-          // firstInvalidQuestion.fields[0].toggleSelection();
           var goToField = firstInvalidQuestion.firstInvalidField() || firstInvalidQuestion.fields[0];
           goToField.toggleSelection();
           goToField.isValid();

--- a/omod/src/main/webapp/resources/scripts/navigator/navigatorHandlers.js
+++ b/omod/src/main/webapp/resources/scripts/navigator/navigatorHandlers.js
@@ -288,7 +288,7 @@ var clickedQuestionHandler = function(questions, question, event) {
     shouldSelectClickedQuestion = shouldSelectClickedQuestion && currentQuestion.onExit();
 
     if(!shouldSelectClickedQuestion) {
-        if ( !currentQuestion.isValid() ) {
+        if ( !currentQuestion.isValid() || !currentQuestion.onExit()) {
           // stay on the current question if it is invalid
           var selectedField = selectedModel(currentQuestion.fields);
           selectedField && selectedField.select();

--- a/omod/src/main/webapp/resources/scripts/navigator/navigatorModels.js
+++ b/omod/src/main/webapp/resources/scripts/navigator/navigatorModels.js
@@ -410,7 +410,7 @@ QuestionModel.prototype.unselect = function() {
     })
 
     // mark the question as done if at least one of the fields has a value, and all the expected fields have a value
-    anyFieldHasValue && !expectedFieldMissingValue ? this.questionLi.addClass("done") :
+    anyFieldHasValue && !expectedFieldMissingValue && this.isValid() ? this.questionLi.addClass("done") :
           this.questionLi.removeClass("done");
 
 }

--- a/omod/src/test/webapp/resources/scripts/navigatorHandlers.js
+++ b/omod/src/test/webapp/resources/scripts/navigatorHandlers.js
@@ -668,7 +668,7 @@ describe("Tests for simple form navigation handlers", function() {
         });
 
         describe("Question mouse handlers", function() {
-           var firstQuestion, secondQuestion, thirdQuestion, field, event, questions;
+           var firstQuestion, secondQuestion, thirdQuestion, field, secondField, event, questions;
             beforeEach(function() {
                 firstQuestion = {isSelected: false, toggleSelection: '', isValid: '', onExit: '', questionLi: $('<li></li>'), select: ''};
                 secondQuestion = {isSelected: false, toggleSelection: '', isValid: '', firstInvalidField: '', onExit: '', questionLi: $('<li></li>')};
@@ -676,6 +676,7 @@ describe("Tests for simple form navigation handlers", function() {
                 event = {stopPropagation: ''};
 
                 field = {isSelected: false, toggleSelection: '', select: ''};
+                secondField = { isSelected: false, toggleSelection: '', select: '', isValid: false };
 
                 questions = [firstQuestion, secondQuestion, thirdQuestion];
             });
@@ -712,7 +713,7 @@ describe("Tests for simple form navigation handlers", function() {
                 expect(event.stopPropagation).toHaveBeenCalled();
                 expect(field.select).toHaveBeenCalled();
             });
-            it("should not switch selection to question ahead if question in between is not valid", function() {
+            it("should not switch selection to question ahead but should switch to invalid question in between", function() {
                 spyOn(event, 'stopPropagation');
                 spyOn(firstQuestion, 'isValid').and.returnValue(true);
                 spyOn(firstQuestion, 'onExit').and.returnValue(true);
@@ -724,12 +725,15 @@ describe("Tests for simple form navigation handlers", function() {
                 firstQuestion.isSelected=true;
                 field.isSelected = true;
                 firstQuestion.fields = [field];
+                spyOn(secondField, 'select');
+                spyOn(secondField, 'toggleSelection');
+                spyOn(secondField, 'isValid').and.returnValue(false);
+                secondQuestion.fields = [ secondField ];
 
                 clickedQuestionHandler(questions, thirdQuestion, event);
 
                 expect(firstQuestion.onExit).not.toHaveBeenCalled();
                 expect(event.stopPropagation).toHaveBeenCalled();
-                expect(field.select).toHaveBeenCalled();
             });
             it("should switch selection to question ahead but not call exit handler on in-between method", function() {
                 spyOn(event, 'stopPropagation');
@@ -784,7 +788,7 @@ describe("Tests for simple form navigation handlers", function() {
                 clickedQuestionHandler(questions, secondQuestion, event);
 
                 expect(event.stopPropagation).toHaveBeenCalled();
-                expect(field.select).toHaveBeenCalled();
+
             });
 
             it("should not switch selection to question behind if exit handler returns false", function() {

--- a/omod/src/test/webapp/resources/scripts/navigatorHandlers.js
+++ b/omod/src/test/webapp/resources/scripts/navigatorHandlers.js
@@ -671,7 +671,7 @@ describe("Tests for simple form navigation handlers", function() {
            var firstQuestion, secondQuestion, thirdQuestion, field, event, questions;
             beforeEach(function() {
                 firstQuestion = {isSelected: false, toggleSelection: '', isValid: '', onExit: '', questionLi: $('<li></li>'), select: ''};
-                secondQuestion = {isSelected: false, toggleSelection: '', isValid: '', onExit: '', questionLi: $('<li></li>')};
+                secondQuestion = {isSelected: false, toggleSelection: '', isValid: '', firstInvalidField: '', onExit: '', questionLi: $('<li></li>')};
                 thirdQuestion = {isSelected: false, toggleSelection: '', questionLi: $('<li></li>')};
                 event = {stopPropagation: ''};
 
@@ -699,8 +699,8 @@ describe("Tests for simple form navigation handlers", function() {
             });
             it("should not switch selection to question ahead if current question is not valid", function() {
                 spyOn(event, 'stopPropagation');
-                spyOn(firstQuestion, 'isValid').and.returnValue(false)
-                spyOn(firstQuestion, 'onExit').and.returnValue(true);;
+                spyOn(firstQuestion, 'isValid').and.returnValue(false);
+                spyOn(firstQuestion, 'onExit').and.returnValue(true);
                 spyOn(field, 'select');
                 firstQuestion.isSelected = true;
                 field.isSelected = true;
@@ -716,7 +716,10 @@ describe("Tests for simple form navigation handlers", function() {
                 spyOn(event, 'stopPropagation');
                 spyOn(firstQuestion, 'isValid').and.returnValue(true);
                 spyOn(firstQuestion, 'onExit').and.returnValue(true);
+                spyOn(firstQuestion, 'toggleSelection');
                 spyOn(secondQuestion, 'isValid').and.returnValue(false);
+                spyOn(secondQuestion, 'toggleSelection');
+                spyOn(secondQuestion, 'firstInvalidField');
                 spyOn(field, 'select');
                 firstQuestion.isSelected=true;
                 field.isSelected = true;

--- a/omod/src/test/webapp/resources/scripts/navigatorHandlers.js
+++ b/omod/src/test/webapp/resources/scripts/navigatorHandlers.js
@@ -732,7 +732,7 @@ describe("Tests for simple form navigation handlers", function() {
 
                 clickedQuestionHandler(questions, thirdQuestion, event);
 
-                expect(firstQuestion.onExit).not.toHaveBeenCalled();
+                expect(firstQuestion.onExit).toHaveBeenCalled();
                 expect(event.stopPropagation).toHaveBeenCalled();
             });
             it("should switch selection to question ahead but not call exit handler on in-between method", function() {
@@ -788,7 +788,7 @@ describe("Tests for simple form navigation handlers", function() {
                 clickedQuestionHandler(questions, secondQuestion, event);
 
                 expect(event.stopPropagation).toHaveBeenCalled();
-
+                expect(field.select).toHaveBeenCalled();
             });
 
             it("should not switch selection to question behind if exit handler returns false", function() {

--- a/omod/src/test/webapp/resources/scripts/navigatorHandlers.js
+++ b/omod/src/test/webapp/resources/scripts/navigatorHandlers.js
@@ -733,6 +733,8 @@ describe("Tests for simple form navigation handlers", function() {
                 clickedQuestionHandler(questions, thirdQuestion, event);
 
                 expect(firstQuestion.onExit).toHaveBeenCalled();
+                expect(secondQuestion.toggleSelection).toHaveBeenCalled();
+                expect(secondField.toggleSelection).toHaveBeenCalled();
                 expect(event.stopPropagation).toHaveBeenCalled();
             });
             it("should switch selection to question ahead but not call exit handler on in-between method", function() {

--- a/omod/src/test/webapp/resources/scripts/navigatorModels.js
+++ b/omod/src/test/webapp/resources/scripts/navigatorModels.js
@@ -219,13 +219,14 @@ describe("Test for simple form models", function() {
 
         beforeEach(function() {
             questionModel = new QuestionModel();
-            firstField = jasmine.createSpyObj('firstField', ['unselect', 'resetErrorMessages', 'value', 'displayValue', 'enable', 'disable', 'hide', 'show']);
+            firstField = jasmine.createSpyObj('firstField', ['unselect', 'resetErrorMessages', 'value', 'displayValue', 'enable', 'disable', 'hide', 'show', 'isValid']);
             secondField = jasmine.createSpyObj('secondField', ['unselect', 'resetErrorMessages', 'value', 'displayValue', 'enable', 'disable', 'hide', 'show']);
             firstField.element = jasmine.createSpyObj('element', ['addClass', 'removeClass', 'hasClass']);
             secondField.element  = jasmine.createSpyObj('element', ['addClass', 'removeClass', 'hasClass']);
             questionModel.fields = [firstField, secondField];
             element = jasmine.createSpyObj('element', ['addClass', 'removeClass', 'triggerHandler', 'attr', 'removeAttr', 'hide', 'show']);
             questionModel.element = element;
+            spyOn(questionModel, 'isValid').and.returnValue(true);
             spyOn(questionModel.questionLi, 'addClass');
             spyOn(questionModel.questionLi, 'removeClass');
             spyOn(questionModel.questionLi, 'show');


### PR DESCRIPTION
@mogoodrich , here is the PR that changes the current behavior of the component in such a way that when the user navigates ahead it nows stops at the in between question with invalid fields. This obvious now is in the contradiction of the unit test that says do not navigate ahead if the in between question has an invalid field:

https://github.com/openmrs/openmrs-module-uicommons/blob/master/omod/src/test/webapp/resources/scripts/navigatorHandlers.js#L715
