### PR TITLE
(fix) Datepicker format

### DIFF
--- a/omod/src/main/webapp/fragments/field/datetimepicker.gsp
+++ b/omod/src/main/webapp/fragments/field/datetimepicker.gsp
@@ -87,7 +87,7 @@
         minuteStep = 5
     }
     if(!datePickerFormat){
-        datePickerFormat = useTime ? "dd M yyyy HH:mm" :"dd M yyyy"
+        datePickerFormat = useTime ? "dd M yyyy HH:ii" :"dd M yyyy"
     }
 
     if(!datePickerLinkFormat){


### PR DESCRIPTION
### Fix Datepicker Format

### Description:
Corrected Datepicker format from "yyyy-mm-dd hh:mm" to "yyyy-mm-dd hh:ii" to resolve confusion between months and minutes in the time section. This issue only occurred when utilizing time in visits, which is false by default.

### Changes:

Updated Datepicker format to "yyyy-mm-dd hh:ii:ss"
### Impact:

Resolves confusion between months and minutes in time section.

