### PR TITLE
(fix) Datepicker time format

### DIFF
--- a/omod/src/main/webapp/fragments/field/datetimepicker.gsp
+++ b/omod/src/main/webapp/fragments/field/datetimepicker.gsp
@@ -87,7 +87,7 @@
         minuteStep = 5
     }
     if(!datePickerFormat){
-        datePickerFormat = useTime ? "dd M yyyy HH:ii" :"dd M yyyy"
+        datePickerFormat = useTime ? "dd M yyyy hh:ii" :"dd M yyyy"
     }
 
     if(!datePickerLinkFormat){


### PR DESCRIPTION
Fix Datepicker time Format
Description:
Corrected Datepicker time format from "HH:ii to "hh:ii" to resolve confusion between 24h time format and 12 time format. This issue only occurred when utilizing time in visits, which is false by default.

Changes:
Updated Datepicker format to "yyyy-mm-dd hh:ii:ss"

Impact:
Resolves confusion between 12h and 24h time formats.