### PR TITLE
UHM-7970: navigate back to the first invalid question

### DIFF
--- a/omod/src/main/webapp/resources/scripts/navigator/navigatorHandlers.js
+++ b/omod/src/main/webapp/resources/scripts/navigator/navigatorHandlers.js
@@ -281,6 +281,10 @@ var clickedQuestionHandler = function(questions, question, event) {
               firstInvalidQuestion = questions[i];
             }
             shouldSelectClickedQuestion = questions[i].isValid() && shouldSelectClickedQuestion;
+            if (!shouldSelectClickedQuestion && firstInvalidQuestion) {
+                // no point on checking if other questions are invalid, need to navigate back to the first invalid question
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
@mogoodrich , this is to fix the bug Fiona discovered in the registration app when clicking on a question that is a few questions past the current question. For some reason the code was checking the validity of each question between the current question and the clicked question. The simple change I made below stops at the first found invalid question and the user is brought back to the first invalid field of the first invalid question without iterating through the rest of the skipped questions. 