### PR TITLE
UHM-8240 always display left nav in HTML form entry

### DIFF
--- a/omod/src/main/webapp/resources/scripts/navigator/navigator.js
+++ b/omod/src/main/webapp/resources/scripts/navigator/navigator.js
@@ -35,18 +35,8 @@ function KeyboardController(formElement) {
     var initFormModels = function(formElement) {
 
         formElement.prepend('<ul id="formBreadcrumb" class="options"></ul>');
-        formElement.append(
-          '<div id="nav-buttons">'
-          + '<button id="prev-button" type="button" class="confirm" style="display:none">'
-          + '  <icon class="fas fa-chevron-left"/>'
-          + '</button>'
-          + '<button id="next-button" class="confirm right" type="button">'
-          + '  <icon class="fas fa-chevron-right"/>'
-          + '</button>'
-          + '</div>');
 
         var breadcrumb = formElement.find('#formBreadcrumb').first();
-        var navButtons = formElement.find('#nav-buttons').first();
 
         var sections = _.map(formElement.find('section'), function(s) {
             return new SectionModel(s, breadcrumb);
@@ -55,8 +45,7 @@ function KeyboardController(formElement) {
         var confirmationSection = new ConfirmationSectionModel(
           $('#confirmation'),
           breadcrumb, _.clone(sections),
-          formElement.hasClass('skip-confirmation-section'),
-          navButtons);
+          formElement.hasClass('skip-confirmation-section'));
         sections.push(confirmationSection);
 
         var questions = _.flatten( _.map(sections, function(s) { return s.questions; }), true);

--- a/omod/src/main/webapp/resources/scripts/navigator/navigatorModels.js
+++ b/omod/src/main/webapp/resources/scripts/navigator/navigatorModels.js
@@ -607,11 +607,10 @@ SectionModel.prototype.firstInvalidQuestion = function() {
 }
 
 
-function ConfirmationSectionModel(elem, formMenuElem, regularSections, skipConfirmation, navButtons) {
+function ConfirmationSectionModel(elem, formMenuElem, regularSections, skipConfirmation) {
     SelectableModel.apply(this, [elem]);
     this.sections = regularSections;
     this.skipConfirmation = skipConfirmation ? skipConfirmation : false;
-    this.navButtons = navButtons;
 
     var title = this.element.find("span.title").first();
     var label = $('<span/>').html(title.text());
@@ -639,7 +638,6 @@ ConfirmationSectionModel.prototype.constructor = ConfirmationSectionModel;
 ConfirmationSectionModel.prototype.select = function() {
     SelectableModel.prototype.select.apply(this);
     this.title.addClass("doing");
-    this.navButtons.hide();
 
     if (!this.skipConfirmation) {
         // scan through the form and confirm that at least one of the fields has a value
@@ -702,7 +700,6 @@ ConfirmationSectionModel.prototype.select = function() {
 ConfirmationSectionModel.prototype.unselect = function() {
     SelectableModel.prototype.unselect.apply(this);
     this.title.removeClass("doing");
-    this.navButtons.show();
     this.dataCanvas.empty();
     _.each(this.questions, function(question) { question.unselect() });
 }

--- a/omod/src/test/webapp/resources/scripts/navigatorModels.js
+++ b/omod/src/test/webapp/resources/scripts/navigatorModels.js
@@ -574,9 +574,8 @@ describe("Test for simple form models", function() {
     describe("Unit tests for ConfirmationSectionModel", function() {
        it("should select and unselect the confirmation section",function() {
            var menuElement = jasmine.createSpyObj('menu', ['append']);
-           var navButtons = jasmine.createSpyObj('navButtons', ['hide','show']);
            var confirmationQuestionModel = jasmine.createSpyObj('confirmationQuestion', ['confirm', 'cancel']);
-           var confirmationSectionModel = new ConfirmationSectionModel( confirmationQuestionModel, menuElement, null, null, navButtons);
+           var confirmationSectionModel = new ConfirmationSectionModel( confirmationQuestionModel, menuElement, null, null);
            confirmationSectionModel.element = jasmine.createSpyObj('element', ['addClass', 'removeClass', 'triggerHandler']);
            confirmationSectionModel.element.find = function () {  // stub out the find method to simply remove an empty jq call
                return jq();
@@ -588,12 +587,10 @@ describe("Test for simple form models", function() {
            confirmationSectionModel.toggleSelection();
            expect(confirmationSectionModel.element.addClass).toHaveBeenCalledWith('focused');
            expect(confirmationSectionModel.isSelected).toBe(true);
-           expect(navButtons.hide).toHaveBeenCalled();
 
            confirmationSectionModel.toggleSelection();
            expect(confirmationSectionModel.element.removeClass).toHaveBeenCalledWith('focused');
            expect(confirmationSectionModel.isSelected).toBe(false);
-           expect(navButtons.show).toHaveBeenCalled();
        });
     });
 })

--- a/scss/src/main/resources/sass/reference/fragments/_form-navigator-ui.scss
+++ b/scss/src/main/resources/sass/reference/fragments/_form-navigator-ui.scss
@@ -163,131 +163,112 @@ form#retrospectiveCheckin {
   }
 }
 
-#nav-buttons {
-  background: #ffffff;
-  padding: 10px;
-}
-
-// we don't display the next/previous button on Bootstrap lg or xl sizes
-@media (min-width: 992px) {   // 992px is set to Bootstrap "lg" size
-  #nav-buttons {
-    display: none;
-  }
-}
-
-// we don't display the form breadcrumb when in Bootstrap xs,sm, or md screen sizes
 ul#formBreadcrumb {
-  display: none;
-}
+  display: block;
+  float: left;
+  vertical-align: top;
+  width: 220px;
 
-@media (min-width: 992px) { // 992px is set to Bootstrap "lg" size
-  ul#formBreadcrumb {
-    display: block;
-    float: left;
-    vertical-align: top;
-    width: 220px;
+  li {
+    border: 1px solid #EEE;
+    border-bottom: none;
+    border-right: none;
 
-    li {
-      border: 1px solid #EEE;
-      border-bottom: none;
-      border-right: none;
+    span {
+      padding: 5px;
+      font-family: $primaryBoldFont;
+    }
 
-      span {
-        padding: 5px;
-        font-family: $primaryBoldFont;
-      }
+    &:first-child {
+      @include border-top-left-radius(4px);
+    }
 
-      &:first-child {
-        @include border-top-left-radius(4px);
-      }
+    &:last-child {
+      border-bottom: 1px solid #EEE;
+      @include border-bottom-left-radius(4px);
+    }
 
-      &:last-child {
-        border-bottom: 1px solid #EEE;
-        @include border-bottom-left-radius(4px);
-      }
-
-      &.doing {
-        border-left: 5px solid $link;
-
-        ul {
-          display: block;
-
-          li {
-            span {
-              padding-left: 27px;
-              padding-right: 0;
-              font-weight: normal;
-              font-family: $primaryFont;
-            }
-
-            border: none;
-            @include border-radius(0);
-
-            &.focused {
-              color: #FFF;
-              background-color: $link;
-            }
-          }
-        }
-
-        .question-legend {
-          .icon-ok {
-            display: none;
-            font-size: 0.7em;
-            border: 2px solid;
-            color: rgb(40, 201, 0);
-            padding: 3px 2px;
-            margin-left: 4px;
-          }
-
-          &.done {
-            span {
-              padding-left: 2px;
-              padding-right: 0;
-              display: inline-block;
-            }
-
-            .icon-ok {
-              display: inline-block;
-            }
-          }
-
-          &.focused {
-            .icon-ok {
-              color: white;
-            }
-          }
-        }
-      }
-
-      i {
-        display: inline-block;
-        font-size: 1em;
-        border: 3px solid;
-        @include border-radius(50%);
-
-        span {
-          font-style: normal;
-          font-weight: 700;
-          padding: 0px 5px;
-          margin-top: -3px;
-        }
-      }
-
-      span {
-        display: inline-block;
-        vertical-align: middle;
-
-        em {
-          display: block;
-          font-size: .7em;
-          text-align: left;
-        }
-      }
+    &.doing {
+      border-left: 5px solid $link;
 
       ul {
-        display: none;
+        display: block;
+
+        li {
+          span {
+            padding-left: 27px;
+            padding-right: 0;
+            font-weight: normal;
+            font-family: $primaryFont;
+          }
+
+          border: none;
+          @include border-radius(0);
+
+          &.focused {
+            color: #FFF;
+            background-color: $link;
+          }
+        }
       }
+
+      .question-legend {
+        .icon-ok {
+          display: none;
+          font-size: 0.7em;
+          border: 2px solid;
+          color: rgb(40, 201, 0);
+          padding: 3px 2px;
+          margin-left: 4px;
+        }
+
+        &.done {
+          span {
+            padding-left: 2px;
+            padding-right: 0;
+            display: inline-block;
+          }
+
+          .icon-ok {
+            display: inline-block;
+          }
+        }
+
+        &.focused {
+          .icon-ok {
+            color: white;
+          }
+        }
+      }
+    }
+
+    i {
+      display: inline-block;
+      font-size: 1em;
+      border: 3px solid;
+      @include border-radius(50%);
+
+      span {
+        font-style: normal;
+        font-weight: 700;
+        padding: 0px 5px;
+        margin-top: -3px;
+      }
+    }
+
+    span {
+      display: inline-block;
+      vertical-align: middle;
+
+      em {
+        display: block;
+        font-size: .7em;
+        text-align: left;
+      }
+    }
+
+    ul {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
This PR makes it so we always show the left nav in HTML form entry, regardless of screen size.

**Disclaimer: I have not be able to test this change locally.** I tried building and doing `openmr-sdk:watch` on both `uicommons` and `htmlformentryui` and couldn't see the changes locally. I did at least run `mvn clean install` to see that tests pass.